### PR TITLE
Update 50unattended-upgrades.j2

### DIFF
--- a/templates/etc/apt/apt.conf.d/50unattended-upgrades.j2
+++ b/templates/etc/apt/apt.conf.d/50unattended-upgrades.j2
@@ -44,7 +44,7 @@ Unattended-Upgrade::Automatic-Reboot "{{ updates_reboot | ternary('true', 'false
 
 Unattended-Upgrade::Automatic-Reboot-WithUsers "{{ updates_reboot_with_users | ternary('true', 'false') }}";
 
-Unattended-Upgrade::Automatic-Reboot-Time "{{ updates_reboot }}";
+Unattended-Upgrade::Automatic-Reboot-Time "{{ updates_reboot_time }}";
 {% endif -%}
 {% if updates_dl_limit > 0 %}
 


### PR DESCRIPTION
correct automatic-reboot-time variable

the wrong variable was used, now the update_reboot_time variable is used